### PR TITLE
feat: generate json model write method

### DIFF
--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/MrwSerializationTypeProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/MrwSerializationTypeProvider.cs
@@ -6,7 +6,9 @@ using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text.Json;
+using Microsoft.CodeAnalysis;
 using Microsoft.Generator.CSharp.ClientModel.Snippets;
 using Microsoft.Generator.CSharp.Expressions;
 using Microsoft.Generator.CSharp.Input;
@@ -22,19 +24,25 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
     /// </summary>
     internal sealed class MrwSerializationTypeProvider : TypeProvider
     {
+        private const string PrivateAdditionalPropertiesPropertyDescription = "Keeps track of any properties unknown to the library.";
+        private const string PrivateAdditionalPropertiesPropertyName = "_serializedAdditionalRawData";
+        private const string JsonModelWriteCoreMethodName = "JsonModelWriteCore";
+        private readonly ParameterProvider _utf8JsonWriterParameter = new("writer", $"The JSON writer.", typeof(Utf8JsonWriter));
         private readonly ParameterProvider _serializationOptionsParameter =
             new("options", $"The client options for reading and writing models.", typeof(ModelReaderWriterOptions));
-        private const string _privateAdditionalPropertiesPropertyDescription = "Keeps track of any properties unknown to the library.";
-        private const string _privateAdditionalPropertiesPropertyName = "_serializedAdditionalRawData";
-        private static readonly CSharpType _privateAdditionalPropertiesPropertyType = typeof(IDictionary<string, BinaryData>);
-        private readonly CSharpType _iJsonModelTInterface;
-        private readonly CSharpType? _iJsonModelObjectInterface;
-        private readonly CSharpType _iPersistableModelTInterface;
-        private readonly CSharpType? _iPersistableModelObjectInterface;
+        private readonly Utf8JsonWriterSnippet _utf8JsonWriterSnippet;
+        private readonly ModelReaderWriterOptionsSnippet _mrwOptionsParameterSnippet;
+        private readonly CSharpType _privateAdditionalPropertiesPropertyType = typeof(IDictionary<string, BinaryData>);
+        private readonly CSharpType _jsonModelTInterface;
+        private readonly CSharpType? _jsonModelObjectInterface;
+        private readonly CSharpType _persistableModelTInterface;
+        private readonly CSharpType? _persistableModelObjectInterface;
         private TypeProvider _model;
-        private InputModelType _inputModel;
+        private readonly InputModelType _inputModel;
         private readonly FieldProvider? _rawDataField;
         private readonly bool _isStruct;
+        // Flag to determine if the model should override the serialization methods
+        private readonly bool _shouldOverrideMethods;
 
         public MrwSerializationTypeProvider(TypeProvider model, InputModelType inputModel)
         {
@@ -42,11 +50,14 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
             _inputModel = inputModel;
             _isStruct = model.DeclarationModifiers.HasFlag(TypeSignatureModifiers.Struct);
             // Initialize the serialization interfaces
-            _iJsonModelTInterface = new CSharpType(typeof(IJsonModel<>), model.Type);
-            _iJsonModelObjectInterface = _isStruct ? (CSharpType)typeof(IJsonModel<object>) : null;
-            _iPersistableModelTInterface = new CSharpType(typeof(IPersistableModel<>), model.Type);
-            _iPersistableModelObjectInterface = _isStruct ? (CSharpType)typeof(IPersistableModel<object>) : null;
+            _jsonModelTInterface = new CSharpType(typeof(IJsonModel<>), model.Type);
+            _jsonModelObjectInterface = _isStruct ? (CSharpType)typeof(IJsonModel<object>) : null;
+            _persistableModelTInterface = new CSharpType(typeof(IPersistableModel<>), model.Type);
+            _persistableModelObjectInterface = _isStruct ? (CSharpType)typeof(IPersistableModel<object>) : null;
             _rawDataField = BuildRawDataField();
+            _shouldOverrideMethods = _model.Inherits != null && _model.Inherits is { IsFrameworkType: false, Implementation: ModelProvider };
+            _utf8JsonWriterSnippet = new Utf8JsonWriterSnippet(_utf8JsonWriterParameter);
+            _mrwOptionsParameterSnippet = new ModelReaderWriterOptionsSnippet(_serializationOptionsParameter);
 
             Name = model.Name;
             Namespace = model.Namespace;
@@ -123,7 +134,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
             var FieldProvider = new FieldProvider(
                 modifiers: FieldModifiers.Private,
                 type: _privateAdditionalPropertiesPropertyType,
-                name: _privateAdditionalPropertiesPropertyName);
+                name: PrivateAdditionalPropertiesPropertyName);
 
             return FieldProvider;
         }
@@ -134,18 +145,25 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
         /// <returns>A list of serialization and deserialization methods for the model.</returns>
         protected override MethodProvider[] BuildMethods()
         {
-            // TO-DO: Add deserialization methods https://github.com/microsoft/typespec/issues/3330
-
-            return new MethodProvider[]
+            var jsonModelWriteCoreMethod = BuildJsonModelWriteCoreMethod();
+            var methods = new List<MethodProvider>()
             {
-                // Add JSON serialization methods
-                BuildJsonModelWriteMethod(),
+                // Add JsonModel serialization methods
+                BuildJsonModelWriteMethod(jsonModelWriteCoreMethod),
+                jsonModelWriteCoreMethod,
                 BuildJsonModelCreateMethod(),
-                // Add IModel methods
-                BuildIModelWriteMethod(),
-                BuildIModelCreateMethod(),
-                BuildIModelGetFormatFromOptionsMethod()
+                // Add PersistableModel serialization methods
+                BuildPersistableModelWriteMethod(),
+                BuildPersistableModelCreateMethod(),
+                BuildPersistableModelGetFormatFromOptionsMethod()
             };
+
+            if (_isStruct)
+            {
+                methods.Add(BuildJsonModelWriteMethodObjectDeclaration());
+            }
+
+            return [.. methods];
         }
 
         /// <summary>
@@ -154,45 +172,77 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
         /// <returns>An array of <see cref="CSharpType"/> types that the model implements.</returns>
         protected override CSharpType[] BuildImplements()
         {
-            int interfaceCount = _iJsonModelObjectInterface != null ? 2 : 1;
+            int interfaceCount = _jsonModelObjectInterface != null ? 2 : 1;
             CSharpType[] interfaces = new CSharpType[interfaceCount];
-            interfaces[0] = _iJsonModelTInterface;
+            interfaces[0] = _jsonModelTInterface;
 
-            if (_iJsonModelObjectInterface != null)
+            if (_jsonModelObjectInterface != null)
             {
-                interfaces[1] = _iJsonModelObjectInterface;
+                interfaces[1] = _jsonModelObjectInterface;
             }
 
             return interfaces;
         }
 
         /// <summary>
-        /// Builds the JSON serialization write method for the model.
+        /// Builds the <see cref="IJsonModel{T}"/> write method for the model.
         /// </summary>
-        internal MethodProvider BuildJsonModelWriteMethod()
+        internal MethodProvider BuildJsonModelWriteMethod(MethodProvider jsonModelWriteCoreMethod)
         {
-            ParameterProvider utf8JsonWriterParameter = new("writer", $"The JSON writer.", typeof(Utf8JsonWriter));
             // void IJsonModel<T>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
             return new MethodProvider
             (
-              new MethodSignature(nameof(IJsonModel<object>.Write), null, MethodSignatureModifiers.None, null, null, new[] { utf8JsonWriterParameter, _serializationOptionsParameter }, ExplicitInterface: _iJsonModelTInterface),
-              // TO-DO: Add body for json properties' serialization https://github.com/microsoft/typespec/issues/3330
-              Snippet.EmptyStatement,
+              new MethodSignature(nameof(IJsonModel<object>.Write), null, MethodSignatureModifiers.None, null, null, [_utf8JsonWriterParameter, _serializationOptionsParameter], ExplicitInterface: _jsonModelTInterface),
+              BuildJsonModelWriteMethodBody(jsonModelWriteCoreMethod),
               this
             );
         }
 
         /// <summary>
-        /// Builds the JSON serialization create method for the model.
+        /// Builds the <see cref="IJsonModel{T}"/> write method for the model object.
+        /// </summary>
+        internal MethodProvider BuildJsonModelWriteMethodObjectDeclaration()
+        {
+            // void IJsonModel<object>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options) => ((IJsonModel<T>)this).Write(writer, options);
+            var castToT = This.CastTo(_jsonModelTInterface);
+            return new MethodProvider
+            (
+              new MethodSignature(nameof(IJsonModel<object>.Write), null, MethodSignatureModifiers.None, null, null, [_utf8JsonWriterParameter, _serializationOptionsParameter], ExplicitInterface: _jsonModelObjectInterface),
+              new InvokeInstanceMethodExpression(castToT, nameof(IJsonModel<object>.Write), [_utf8JsonWriterParameter, _serializationOptionsParameter]),
+              this
+            );
+        }
+
+        /// <summary>
+        /// Builds the <see cref="IJsonModel{T}"/> write core method for the model.
+        /// </summary>
+        internal MethodProvider BuildJsonModelWriteCoreMethod()
+        {
+            MethodSignatureModifiers modifiers = MethodSignatureModifiers.Protected | MethodSignatureModifiers.Virtual;
+            if (_shouldOverrideMethods)
+            {
+                modifiers = MethodSignatureModifiers.Protected | MethodSignatureModifiers.Override;
+            }
+            // void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+            return new MethodProvider
+            (
+              new MethodSignature(JsonModelWriteCoreMethodName, null, modifiers, null, null, [_utf8JsonWriterParameter, _serializationOptionsParameter]),
+              BuildJsonModelWriteCoreMethodBody(),
+              this
+            );
+        }
+
+        /// <summary>
+        /// Builds the <see cref="IJsonModel{T}"/> create method for the model.
         /// </summary>
         internal MethodProvider BuildJsonModelCreateMethod()
         {
             ParameterProvider utf8JsonReaderParameter = new("reader", $"The JSON reader.", typeof(Utf8JsonReader), isRef: true);
             // T IJsonModel<T>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)
-            var typeOfT = GetModelArgumentType(_iJsonModelTInterface);
+            var typeOfT = GetModelArgumentType(_jsonModelTInterface);
             return new MethodProvider
             (
-              new MethodSignature(nameof(IJsonModel<object>.Create), null, MethodSignatureModifiers.None, typeOfT, null, new[] { utf8JsonReaderParameter, _serializationOptionsParameter }, ExplicitInterface: _iJsonModelTInterface),
+              new MethodSignature(nameof(IJsonModel<object>.Create), null, MethodSignatureModifiers.None, typeOfT, null, new[] { utf8JsonReaderParameter, _serializationOptionsParameter }, ExplicitInterface: _jsonModelTInterface),
               // TO-DO: Call the base model ctor for now until the model properties are serialized https://github.com/microsoft/typespec/issues/3330
               Snippet.Return(new NewInstanceExpression(typeOfT, Array.Empty<ValueExpression>())),
               this
@@ -200,32 +250,32 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
         }
 
         /// <summary>
-        /// Builds the I model write method.
+        /// Builds the <see cref="IPersistableModel{T}"/> write method.
         /// </summary>
-        internal MethodProvider BuildIModelWriteMethod()
+        internal MethodProvider BuildPersistableModelWriteMethod()
         {
             // BinaryData IPersistableModel<T>.Write(ModelReaderWriterOptions options)
             var returnType = typeof(BinaryData);
             return new MethodProvider
             (
-                new MethodSignature(nameof(IPersistableModel<object>.Write), null, MethodSignatureModifiers.None, returnType, null, new[] { _serializationOptionsParameter }, ExplicitInterface: _iPersistableModelTInterface),
+                new MethodSignature(nameof(IPersistableModel<object>.Write), null, MethodSignatureModifiers.None, returnType, null, new[] { _serializationOptionsParameter }, ExplicitInterface: _persistableModelTInterface),
                 // TO-DO: Call the base model ctor for now until the model properties are serialized https://github.com/microsoft/typespec/issues/3330
-                Snippet.Return(new NewInstanceExpression(returnType, [Snippet.Literal(_iPersistableModelTInterface.Name)])),
+                Snippet.Return(new NewInstanceExpression(returnType, [Snippet.Literal(_persistableModelTInterface.Name)])),
                 this
             );
         }
 
         /// <summary>
-        /// Builds the I model create method.
+        /// Builds the <see cref="IPersistableModel{T}"/> create method.
         /// </summary>
-        internal MethodProvider BuildIModelCreateMethod()
+        internal MethodProvider BuildPersistableModelCreateMethod()
         {
             ParameterProvider dataParameter = new("data", $"The data to parse.", typeof(BinaryData));
             // IPersistableModel<T>.Create(BinaryData data, ModelReaderWriterOptions options)
-            var typeOfT = GetModelArgumentType(_iPersistableModelTInterface);
+            var typeOfT = GetModelArgumentType(_persistableModelTInterface);
             return new MethodProvider
             (
-                new MethodSignature(nameof(IPersistableModel<object>.Create), null, MethodSignatureModifiers.None, typeOfT, null, new[] { dataParameter, _serializationOptionsParameter }, ExplicitInterface: _iPersistableModelTInterface),
+                new MethodSignature(nameof(IPersistableModel<object>.Create), null, MethodSignatureModifiers.None, typeOfT, null, new[] { dataParameter, _serializationOptionsParameter }, ExplicitInterface: _persistableModelTInterface),
                 // TO-DO: Call the base model ctor for now until the model properties are serialized https://github.com/microsoft/typespec/issues/3330
                 Snippet.Return(new NewInstanceExpression(typeOfT, Array.Empty<ValueExpression>())),
                 this
@@ -233,15 +283,15 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
         }
 
         /// <summary>
-        /// Builds the I model GetFormatFromOptions method.
+        /// Builds the <see cref="IPersistableModel{T}"/> GetFormatFromOptions method.
         /// </summary>
-        internal MethodProvider BuildIModelGetFormatFromOptionsMethod()
+        internal MethodProvider BuildPersistableModelGetFormatFromOptionsMethod()
         {
             ValueExpression jsonWireFormat = SystemSnippet.JsonFormatSerialization;
             // ModelReaderWriterFormat IPersistableModel<T>.GetFormatFromOptions(ModelReaderWriterOptions options)
             return new MethodProvider
             (
-                new MethodSignature(nameof(IPersistableModel<object>.GetFormatFromOptions), null, MethodSignatureModifiers.None, typeof(string), null, new[] { _serializationOptionsParameter }, ExplicitInterface: _iPersistableModelTInterface),
+                new MethodSignature(nameof(IPersistableModel<object>.GetFormatFromOptions), null, MethodSignatureModifiers.None, typeof(string), null, new[] { _serializationOptionsParameter }, ExplicitInterface: _persistableModelTInterface),
                 jsonWireFormat,
                 this
             );
@@ -266,6 +316,47 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
                     GetPropertyInitializers(serializationCtorParameters)
                 },
                 this);
+        }
+
+        /// <summary>
+        /// Constructs the body of the JsonModel write method.
+        /// </summary>
+        /// <param name="jsonModelWriteCoreMethod">The json model write method provider.</param>
+        /// <returns></returns>
+        private MethodBodyStatement[] BuildJsonModelWriteMethodBody(MethodProvider jsonModelWriteCoreMethod)
+        {
+            var coreMethodSignature = jsonModelWriteCoreMethod.Signature;
+            var coreMethodSignatureParameters = coreMethodSignature.Parameters.Select(p => (ValueExpression)p).ToList();
+
+            return
+            [
+                _utf8JsonWriterSnippet.WriteStartObject(),
+                new InvokeInstanceMethodStatement(This, coreMethodSignature.Name, coreMethodSignatureParameters),
+                _utf8JsonWriterSnippet.WriteEndObject(),
+            ];
+        }
+
+        /// <summary>
+        /// Builds the method body for the json model write core method.
+        /// </summary>
+        /// <returns>An array of MethodBodyStatement representing body for the JsonModelWriteCore method.</returns>
+        private MethodBodyStatement[] BuildJsonModelWriteCoreMethodBody()
+        {
+            return
+            [
+                CreateValidateJsonFormat(_persistableModelTInterface, SerializationFormatValidationType.Write),
+                CallBaseJsonModelWriteCore(),
+                CreateWritePropertiesStatements(),
+                CreateWriteAdditionalRawDataStatement()
+            ];
+        }
+
+        private MethodBodyStatement CallBaseJsonModelWriteCore()
+        {
+            // base.<JsonModelWriteCore>()
+            return _shouldOverrideMethods ?
+                new InvokeInstanceMethodStatement(Base, JsonModelWriteCoreMethodName, [_utf8JsonWriterParameter, _serializationOptionsParameter])
+                : EmptyStatement;
         }
 
         private MethodBodyStatement GetPropertyInitializers(IReadOnlyList<ParameterProvider> parameters)
@@ -317,7 +408,7 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
             {
                 constructorParameters.Add(new ParameterProvider(
                     _rawDataField.Name.ToVariableName(),
-                    FormattableStringHelpers.FromString(_privateAdditionalPropertiesPropertyDescription),
+                    FormattableStringHelpers.FromString(PrivateAdditionalPropertiesPropertyDescription),
                     _rawDataField.Type));
             }
 
@@ -331,6 +422,426 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
                 signature: new ConstructorSignature(Type, $"Initializes a new instance of {Type:C} for deserialization.", accessibility, Array.Empty<ParameterProvider>()),
                 bodyStatements: new MethodBodyStatement(),
                 this);
+        }
+
+        /// <summary>
+        /// Produces the validation body statements for the JSON serialization format.
+        /// </summary>
+        private MethodBodyStatement CreateValidateJsonFormat(CSharpType modelInterface, SerializationFormatValidationType validationType)
+        {
+            /*
+                var format = options.Format == "W" ? GetFormatFromOptions(options) : options.Format;
+                if (format != <formatValue>)
+                {
+                    throw new FormatException($"The model {nameof(ThisModel)} does not support '{format}' format.");
+                }
+            */
+            MethodBodyStatement[] statements =
+            [
+                GetConcreteFormat(_mrwOptionsParameterSnippet, modelInterface, out VariableExpression format),
+                new IfStatement(NotEqual(format, ModelReaderWriterOptionsSnippet.JsonFormat))
+                {
+                    ThrowValidationFailException(format, modelInterface.Arguments[0], validationType)
+                },
+            ];
+
+            return statements;
+        }
+
+        private MethodBodyStatement GetConcreteFormat(ModelReaderWriterOptionsSnippet options, CSharpType iModelTInterface, out VariableExpression format)
+        {
+            var castSnippet = new StringSnippet(This.CastTo(iModelTInterface).Invoke(nameof(IPersistableModel<object>.GetFormatFromOptions), options));
+            var condition = new TernaryConditionalExpression(
+                Equal(options.Format, ModelReaderWriterOptionsSnippet.WireFormat),
+                castSnippet,
+                options.Format);
+            var reference = new VariableExpression(castSnippet.Type, "format");
+            format = reference;
+            return Var(reference, condition);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="KeywordStatement"/> of type <see cref="FormatException"/> with a specific message indicating
+        /// that the model does not support the specified serialization format.
+        /// </summary>
+        /// <param name="format">The serialization format.</param>
+        /// <param name="typeOfT">The type of the model.</param>
+        /// <param name="validationType">The type of validation (write or read).</param>
+        /// <returns>The <see cref="MethodBodyStatement"/> representing the throw statement.</returns>
+        private KeywordStatement ThrowValidationFailException(ValueExpression format, CSharpType typeOfT, SerializationFormatValidationType validationType)
+            => Throw(New.Instance(
+                typeof(FormatException),
+                new FormattableStringExpression($"The model {{{0}}} does not support {(validationType == SerializationFormatValidationType.Write ? "writing" : "reading")} '{{{1}}}' format.",
+                [
+                    Nameof(typeOfT),
+                    format
+                ])));
+
+        /// <summary>
+        /// Constructs the body statements for the JsonModelWriteCore method containing the serialization for the model properties.
+        /// </summary>
+        private MethodBodyStatement[] CreateWritePropertiesStatements()
+        {
+            var propertyCount = _model.Properties.Count;
+            var propertyStatements = new MethodBodyStatement[propertyCount];
+            for (var i = 0; i < propertyCount; i++)
+            {
+                var prop = _model.Properties[i];
+                var propertyMember = new MemberExpression(null, prop.Name);
+                var propSerializationFormat = prop.SerializationInfo?.SerializationFormat ?? SerializationFormat.Default;
+
+                // Generate the serialization statements for the property
+                var writePropertySerializationStatements = new MethodBodyStatement[]
+                {
+                    _utf8JsonWriterSnippet.WritePropertyName(prop.Name.ToVariableName()),
+                    CreateSerializationStatement(prop.Type, propertyMember, propSerializationFormat)
+                };
+
+                // Wrap the serialization statement in a check for whether the property is defined
+                var wrapInIsDefinedStatement = WrapInIsDefined(prop, propertyMember, writePropertySerializationStatements);
+                propertyStatements[i] = prop.IsReadOnly ?
+                    WrapInCheckNotWireIfStatement(_mrwOptionsParameterSnippet.Format, wrapInIsDefinedStatement)
+                    : wrapInIsDefinedStatement;
+            }
+
+            return propertyStatements;
+        }
+
+        /// <summary>
+        /// Wraps the serialization statement in a condition check to ensure only initialized and required properties are serialized.
+        /// </summary>
+        /// <param name="propertyProvider">The model property.</param>
+        /// <param name="propertyMemberExpression">The expression representing the property to serialize.</param>
+        /// <param name="writePropertySerializationStatement">The serialization statement to conditionally execute.</param>
+        /// <returns>A method body statement that includes condition checks before serialization.</returns>
+        private MethodBodyStatement WrapInIsDefined(
+            PropertyProvider propertyProvider,
+            MemberExpression propertyMemberExpression,
+            MethodBodyStatement writePropertySerializationStatement)
+        {
+            var propertyType = propertyProvider.Type;
+            var propertySerialization = propertyProvider.SerializationInfo;
+            var isPropRequired = propertySerialization?.IsRequired ?? false;
+
+            if (propertyType.IsNullable)
+            {
+                writePropertySerializationStatement = CheckPropertyIsInitialized(
+                propertyProvider,
+                isPropRequired,
+                propertyMemberExpression,
+                writePropertySerializationStatement);
+            }
+
+            // Directly return the statement if the property is required or a non-nullable value type that is not JsonElement
+            if (IsRequiredOrNonNullableValueType(propertyType, isPropRequired))
+            {
+                return writePropertySerializationStatement;
+            }
+
+            // Conditionally serialize based on whether the property is a collection or a single value
+            return CreateConditionalSerializationStatement(propertyType, propertyMemberExpression, writePropertySerializationStatement);
+        }
+
+        private MethodBodyStatement CheckPropertyIsInitialized(
+            PropertyProvider propertyProvider,
+            bool isPropRequired,
+            MemberExpression propertyMemberExpression,
+            MethodBodyStatement writePropertySerializationStatements)
+        {
+            var propertyType = propertyProvider.Type;
+            BoolSnippet propertyIsInitialized;
+            var propertySerialization = propertyProvider.SerializationInfo;
+            var propName = propertySerialization?.SerializedName ?? propertyProvider.Name;
+
+            if (propertyType.IsCollection && !propertyType.IsReadOnlyMemory && isPropRequired)
+            {
+                propertyIsInitialized = And(NotEqual(propertyMemberExpression, Null),
+                    OptionalSnippet.IsCollectionDefined(new StringSnippet(propertyMemberExpression)));
+            }
+            else
+            {
+                propertyIsInitialized = NotEqual(propertyMemberExpression, Null);
+            }
+
+            return new IfElseStatement(
+                propertyIsInitialized,
+                writePropertySerializationStatements,
+                _utf8JsonWriterSnippet.WriteNull(propName));
+        }
+
+        /// <summary>
+        /// Adds a `format != "W"` around the statement <paramref name="statement"/>.
+        /// If the statement is not an IfStatement, we just create an IfStatement and return.
+        /// If the statement is an IfStatement, we could add the condition to its condition which should simplify the generated code.
+        /// </summary>
+        private IfStatement WrapInCheckNotWireIfStatement(ValueExpression format, MethodBodyStatement statement)
+        {
+            var isNotWireCondition = NotEqual(format, ModelReaderWriterOptionsSnippet.WireFormat);
+            if (statement is IfStatement ifStatement)
+            {
+                var updatedCondition = And(isNotWireCondition, new BoolSnippet(ifStatement.Condition));
+                IfStatement updatedIf = new(updatedCondition, ifStatement.Inline, ifStatement.AddBraces)
+                {
+                    ifStatement.Body
+                };
+                return updatedIf;
+            }
+
+            return new IfStatement(isNotWireCondition)
+            {
+                statement
+            };
+        }
+
+        /// <summary>
+        /// Creates a serialization statement for the specified type.
+        /// </summary>
+        /// <param name="serializationType">The type being serialized.</param>
+        /// <param name="value">The value to be serialized.</param>
+        /// <param name="serializationFormat">The serialization format.</param>
+        /// <returns>The serialization statement.</returns>
+        /// <exception cref="NotSupportedException">Thrown when the serialization type is not supported.</exception>
+        private MethodBodyStatement CreateSerializationStatement(
+            CSharpType serializationType,
+            ValueExpression value,
+            SerializationFormat serializationFormat)
+        {
+            MethodBodyStatement? serializationStatement = null;
+            switch (serializationType)
+            {
+                case var dictionaryType when dictionaryType.IsDictionary:
+                    serializationStatement = CreateDictionarySerializationStatement(
+                        new DictionarySnippet(dictionaryType.Arguments[0], dictionaryType.Arguments[1], value),
+                        serializationFormat);
+                    break;
+                case var listType when listType.IsList || listType.IsArray:
+                    serializationStatement = CreateListSerializationStatement(
+                        GetEnumerableExpression(value, listType),
+                        serializationFormat);
+                    break;
+                case var frameworkType when !frameworkType.IsCollection:
+                    serializationStatement = SerializeValue(serializationType, serializationFormat, value);
+                    break;
+            }
+
+            return serializationStatement ?? throw new NotSupportedException($"Serialization of type {serializationType.Name} is not supported.");
+        }
+
+        private MethodBodyStatement CreateDictionarySerializationStatement(
+            DictionarySnippet dictionary,
+            SerializationFormat serializationFormat)
+        {
+            return new[]
+            {
+                _utf8JsonWriterSnippet.WriteStartObject(),
+                new ForeachStatement("item", dictionary, out KeyValuePairSnippet keyValuePair)
+                {
+                    _utf8JsonWriterSnippet.WritePropertyName(keyValuePair.Key),
+                    TypeRequiresNullCheckInSerialization(keyValuePair.ValueType) ?
+                    new IfStatement(Equal(keyValuePair.Value, Null)) { _utf8JsonWriterSnippet.WriteNullValue(), Continue }: EmptyStatement,
+                    CreateSerializationStatement(keyValuePair.ValueType, keyValuePair.Value, serializationFormat)
+                },
+                _utf8JsonWriterSnippet.WriteEndObject()
+            };
+        }
+
+        private MethodBodyStatement CreateListSerializationStatement(
+            EnumerableSnippet array,
+            SerializationFormat serializationFormat)
+        {
+            return new[]
+            {
+                _utf8JsonWriterSnippet.WriteStartArray(),
+                new ForeachStatement("item", array, out VariableExpression item)
+                {
+                    TypeRequiresNullCheckInSerialization(item.Type) ?
+                    new IfStatement(Equal(item, Null)) { _utf8JsonWriterSnippet.WriteNullValue(), Continue } : EmptyStatement,
+                    CreateSerializationStatement(item.Type, item, serializationFormat)
+                },
+                _utf8JsonWriterSnippet.WriteEndArray()
+            };
+        }
+
+        private MethodBodyStatement? SerializeValue(
+            CSharpType type,
+            SerializationFormat serializationFormat,
+            ValueExpression value)
+        {
+            return type switch
+            {
+                { SerializeAs: not null } or { IsFrameworkType: true } =>
+                    SerializeFrameworkTypeValue(type, serializationFormat, value, type.SerializeAs ?? type.FrameworkType),
+                { Implementation: EnumProvider enumProvider } =>
+                    SerializeEnumProvider(enumProvider, type, value),
+                { Implementation: ModelProvider modelProvider } =>
+                    _utf8JsonWriterSnippet.WriteObjectValue(new TypeProviderSnippet(modelProvider, value), options: _mrwOptionsParameterSnippet),
+                _ => null
+            };
+        }
+
+        private MethodBodyStatement? SerializeEnumProvider(
+            EnumProvider enumProvider,
+            CSharpType type,
+            ValueExpression value)
+        {
+            var enumerableSnippet = new EnumerableSnippet(type, value.NullableStructValue(type));
+            if ((EnumIsIntValueType(enumProvider) && !enumProvider.IsExtensible) || EnumIsNumericValueType(enumProvider))
+            {
+                return _utf8JsonWriterSnippet.WriteNumberValue(enumProvider.ToSerial(enumerableSnippet));
+            }
+            else
+            {
+                return _utf8JsonWriterSnippet.WriteStringValue(enumProvider.ToSerial(enumerableSnippet));
+            }
+        }
+
+        private MethodBodyStatement SerializeFrameworkTypeValue(
+            CSharpType type,
+            SerializationFormat serializationFormat,
+            ValueExpression value,
+            Type frameworkType)
+        {
+            if (frameworkType == typeof(JsonElement))
+            {
+                return new JsonElementSnippet(value).WriteTo(_utf8JsonWriterSnippet);
+            }
+
+            if (frameworkType == typeof(Nullable<>))
+            {
+                frameworkType = type.Arguments[0].FrameworkType;
+            }
+
+            value = value.NullableStructValue(type);
+
+            if (frameworkType == typeof(decimal) ||
+                frameworkType == typeof(double) ||
+                frameworkType == typeof(float) ||
+                frameworkType == typeof(long) ||
+                frameworkType == typeof(int) ||
+                frameworkType == typeof(short) ||
+                frameworkType == typeof(sbyte) ||
+                frameworkType == typeof(byte))
+            {
+                return _utf8JsonWriterSnippet.WriteNumberValue(value);
+            }
+
+            if (frameworkType == typeof(object))
+            {
+                return _utf8JsonWriterSnippet.WriteObjectValue(new FrameworkTypeSnippet(frameworkType, value), _mrwOptionsParameterSnippet);
+            }
+
+            if (frameworkType == typeof(string) || frameworkType == typeof(char) || frameworkType == typeof(Guid))
+            {
+                return _utf8JsonWriterSnippet.WriteStringValue(value);
+            }
+
+            if (frameworkType == typeof(bool))
+            {
+                return _utf8JsonWriterSnippet.WriteBooleanValue(value);
+            }
+
+            if (frameworkType == typeof(byte[]))
+            {
+                return _utf8JsonWriterSnippet.WriteBase64StringValue(value, serializationFormat.ToFormatSpecifier());
+            }
+
+            if (frameworkType == typeof(DateTimeOffset) || frameworkType == typeof(DateTime) || frameworkType == typeof(TimeSpan))
+            {
+                var format = serializationFormat.ToFormatSpecifier();
+
+                if (serializationFormat is SerializationFormat.Duration_Seconds)
+                {
+                    return _utf8JsonWriterSnippet.WriteNumberValue(ConvertSnippet.InvokeToInt32(new TimeSpanSnippet(value).InvokeToString(format)));
+                }
+
+                if (serializationFormat is SerializationFormat.Duration_Seconds_Float or SerializationFormat.Duration_Seconds_Double)
+                {
+                    return _utf8JsonWriterSnippet.WriteNumberValue(ConvertSnippet.InvokeToDouble(new TimeSpanSnippet(value).InvokeToString(format)));
+                }
+
+                if (serializationFormat is SerializationFormat.DateTime_Unix)
+                {
+                    return _utf8JsonWriterSnippet.WriteNumberValue(value, format);
+                }
+
+                return format is not null
+                    ? _utf8JsonWriterSnippet.WriteStringValue(value, format)
+                    : _utf8JsonWriterSnippet.WriteStringValue(value);
+            }
+
+            if (frameworkType == typeof(IPAddress))
+            {
+                return _utf8JsonWriterSnippet.WriteStringValue(value.InvokeToString());
+            }
+
+            if (frameworkType == typeof(Uri))
+            {
+                return _utf8JsonWriterSnippet.WriteStringValue(new MemberExpression(value, nameof(Uri.AbsoluteUri)));
+            }
+
+            if (frameworkType == typeof(BinaryData))
+            {
+                var binaryDataValue = new BinaryDataSnippet(value);
+                if (serializationFormat is SerializationFormat.Bytes_Base64 or SerializationFormat.Bytes_Base64Url)
+                {
+                    return _utf8JsonWriterSnippet.WriteBase64StringValue(new BinaryDataSnippet(value).ToArray(), serializationFormat.ToFormatSpecifier());
+                }
+
+                return _utf8JsonWriterSnippet.WriteBinaryData(binaryDataValue);
+            }
+            if (frameworkType == typeof(Stream))
+            {
+                return _utf8JsonWriterSnippet.WriteBinaryData(BinaryDataSnippet.FromStream(value, false));
+            }
+
+            throw new NotSupportedException($"Framework type {frameworkType} serialization not supported.");
+        }
+
+        private EnumerableSnippet GetEnumerableExpression(ValueExpression expression, CSharpType enumerableType)
+        {
+            CSharpType itemType = enumerableType.IsReadOnlyMemory ? new CSharpType(typeof(ReadOnlySpan<>), enumerableType.Arguments[0]) :
+                enumerableType.ElementType;
+
+            return new EnumerableSnippet(itemType, expression);
+        }
+
+        private bool IsRequiredOrNonNullableValueType(CSharpType propertyType, bool isRequired)
+            => isRequired || (!propertyType.IsNullable && propertyType.IsValueType && !propertyType.Equals(typeof(JsonElement)));
+
+        private MethodBodyStatement CreateConditionalSerializationStatement(CSharpType propertyType, MemberExpression propertyMemberExpression, MethodBodyStatement writePropertySerializationStatement)
+        {
+            var condition = propertyType.IsCollection && !propertyType.IsReadOnlyMemory
+                ? OptionalSnippet.IsCollectionDefined(new StringSnippet(propertyMemberExpression))
+                : OptionalSnippet.IsDefined(new StringSnippet(propertyMemberExpression));
+
+            return new IfStatement(condition) { writePropertySerializationStatement };
+        }
+
+        /// <summary>
+        /// Builds the JSON write core body statement for the additional raw data.
+        /// </summary>
+        /// <returns>The method body statement that writes the additional raw data.</returns>
+        private MethodBodyStatement CreateWriteAdditionalRawDataStatement()
+        {
+            if (_rawDataField == null)
+            {
+                return EmptyStatement;
+            }
+
+            var rawDataMemberExp = new MemberExpression(null, _rawDataField.Name);
+            var rawDataDictionaryExp = new DictionarySnippet(_rawDataField.Type.Arguments[0], _rawDataField.Type.Arguments[1], rawDataMemberExp);
+            var forEachStatement = new ForeachStatement("item", rawDataDictionaryExp, out KeyValuePairSnippet item)
+            {
+                _utf8JsonWriterSnippet.WritePropertyName(item.Key),
+                CreateSerializationStatement(_rawDataField.Type.Arguments[1], item.Value, SerializationFormat.Default),
+            };
+
+            var ifNotEqualToNullStatement = new IfStatement(NotEqual(rawDataDictionaryExp, Null))
+            {
+                forEachStatement,
+            };
+
+            return WrapInCheckNotWireIfStatement(_mrwOptionsParameterSnippet.Format, ifNotEqualToNullStatement);
         }
 
         /// <summary>
@@ -348,6 +859,48 @@ namespace Microsoft.Generator.CSharp.ClientModel.Providers
             }
 
             return interfaceArgs[0];
+        }
+
+        /// <summary>
+        /// Determines if the type requires a null check in serialization.
+        /// </summary>
+        /// <param name="type">The <see cref="CSharpType"/> to validate.</param>
+        /// <returns><c>true</c> if the type requires a null check.</returns>
+        private bool TypeRequiresNullCheckInSerialization(CSharpType type)
+        {
+            if (type.IsCollection)
+            {
+                return true;
+            }
+            else if (type.IsNullable && type.IsValueType) // nullable value type
+            {
+                return true;
+            }
+            else if (!type.IsValueType && type.IsFrameworkType
+                && (type.FrameworkType != typeof(string) || type.FrameworkType != typeof(byte[])))
+            {
+                // reference type, excluding string or byte[]
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool EnumIsIntValueType(EnumProvider enumProvider)
+        {
+            var frameworkType = enumProvider.ValueType;
+            return frameworkType.Equals(typeof(int)) || frameworkType.Equals(typeof(long));
+        }
+
+        private bool EnumIsFloatValueType(EnumProvider enumProvider)
+        {
+            var frameworkType = enumProvider.ValueType;
+            return frameworkType.Equals(typeof(float)) || frameworkType.Equals(typeof(double));
+        }
+
+        private bool EnumIsNumericValueType(EnumProvider enumProvider)
+        {
+            return EnumIsIntValueType(enumProvider) || EnumIsFloatValueType(enumProvider);
         }
     }
 }

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/SerializationFormatValidationType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.ClientModel/src/Providers/SerializationFormatValidationType.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Generator.CSharp.ClientModel
+{
+    internal enum SerializationFormatValidationType
+    {
+        Write,
+        Read
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/Serialization/SerializationFormatExtensions.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp.Input/src/InputTypes/Serialization/SerializationFormatExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Generator.CSharp.Input
+{
+    public static class SerializationFormatExtensions
+    {
+        public static string? ToFormatSpecifier(this SerializationFormat format) => format switch
+        {
+            SerializationFormat.DateTime_RFC1123 => "R",
+            SerializationFormat.DateTime_RFC3339 => "O",
+            SerializationFormat.DateTime_RFC7231 => "R",
+            SerializationFormat.DateTime_ISO8601 => "O",
+            SerializationFormat.Date_ISO8601 => "D",
+            SerializationFormat.DateTime_Unix => "U",
+            SerializationFormat.Bytes_Base64Url => "U",
+            SerializationFormat.Bytes_Base64 => "D",
+            SerializationFormat.Duration_ISO8601 => "P",
+            SerializationFormat.Duration_Constant => "c",
+            SerializationFormat.Duration_Seconds => "%s",
+            SerializationFormat.Duration_Seconds_Float => "s\\.FFF",
+            SerializationFormat.Duration_Seconds_Double => "s\\.FFFFFF",
+            SerializationFormat.Time_ISO8601 => "T",
+            _ => null
+        };
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/OutputTypes/CSharpType.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/OutputTypes/CSharpType.cs
@@ -48,11 +48,11 @@ namespace Microsoft.Generator.CSharp
         private CSharpType? _inputType;
         private CSharpType? _outputType;
         public bool IsReadOnlyMemory => _isReadOnlyMemory ??= TypeIsReadOnlyMemory();
-        internal bool IsList => _isList ??= TypeIsList();
-        internal bool IsArray => _isArray ??= TypeIsArray();
+        public bool IsList => _isList ??= TypeIsList();
+        public bool IsArray => _isArray ??= TypeIsArray();
         internal bool IsReadOnlyList => _isReadOnlyList ??= TypeIsReadOnlyList();
         internal bool IsReadWriteList => _isReadWriteList ??= TypeIsReadWriteList();
-        internal bool IsDictionary => _isDictionary ??= TypeIsDictionary();
+        public bool IsDictionary => _isDictionary ??= TypeIsDictionary();
         internal bool IsReadOnlyDictionary => _isReadOnlyDictionary ??= TypeIsReadOnlyDictionary();
         internal bool IsReadWriteDictionary => _isReadWriteDictionary ??= TypeIsReadWriteDictionary();
         internal bool IsIEnumerableOfT => _isIEnumerableOfT ??= TypeIsIEnumerableOfT();

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/PropertyProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/PropertyProvider.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Generator.CSharp.Providers
         public PropertyBody Body { get; }
         public CSharpType? ExplicitInterface { get; }
         public XmlDocProvider XmlDocs { get; }
+        public PropertySerializationProvider? SerializationInfo { get; }
+        public bool IsReadOnly { get; init; }
 
         public PropertyProvider(InputModelProperty inputProperty)
         {
@@ -36,9 +38,16 @@ namespace Microsoft.Generator.CSharp.Providers
             Description = string.IsNullOrEmpty(inputProperty.Description) ? PropertyDescriptionBuilder.CreateDefaultPropertyDescription(Name, !Body.HasSetter) : $"{inputProperty.Description}";
             XmlDocSummary = PropertyDescriptionBuilder.BuildPropertyDescription(inputProperty, propertyType, serializationFormat, Description);
             XmlDocs = GetXmlDocs();
+            IsReadOnly = inputProperty.IsReadOnly;
+            SerializationInfo = new PropertySerializationProvider(inputProperty);
         }
 
-        public PropertyProvider(FormattableString? description, MethodSignatureModifiers modifiers, CSharpType type, string name, PropertyBody body, CSharpType? explicitInterface = null)
+        public PropertyProvider(
+            FormattableString? description,
+            MethodSignatureModifiers modifiers,
+            CSharpType type, string name,
+            PropertyBody body,
+            CSharpType? explicitInterface = null)
         {
             Description = description ?? PropertyDescriptionBuilder.CreateDefaultPropertyDescription(name, !body.HasSetter);
             XmlDocSummary = new XmlDocSummaryStatement([Description]);

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/PropertySerializationProvider.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Providers/PropertySerializationProvider.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Generator.CSharp.Input;
+
+namespace Microsoft.Generator.CSharp.Providers
+{
+    public class PropertySerializationProvider
+    {
+        public SerializationFormat SerializationFormat { get; }
+        public bool IsRequired { get; }
+        public string SerializedName { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertySerializationProvider"/> class.
+        /// </summary>
+        /// <param name="inputModelProperty">The input model property.</param>
+        internal PropertySerializationProvider(InputModelProperty inputModelProperty)
+        {
+            SerializationFormat = CodeModelPlugin.Instance.TypeFactory.GetSerializationFormat(inputModelProperty.Type);
+            IsRequired = inputModelProperty.IsRequired;
+            SerializedName = inputModelProperty.SerializedName;
+        }
+    }
+}

--- a/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Snippets/Snippet.cs
+++ b/packages/http-client-csharp/generator/Microsoft.Generator.CSharp/src/Snippets/Snippet.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Generator.CSharp.Snippets
         public static ValueExpression Default { get; } = new KeywordExpression("default", null);
         public static ValueExpression Null { get; } = new KeywordExpression("null", null);
         public static ValueExpression This { get; } = new KeywordExpression("this", null);
+        public static ValueExpression Base { get; } = new KeywordExpression("base", null);
         public static BoolSnippet True { get; } = new(new KeywordExpression("true", null));
         public static BoolSnippet False { get; } = new(new KeywordExpression("false", null));
 

--- a/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/Friend.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/Friend.Serialization.cs
@@ -26,6 +26,37 @@ namespace UnbrandedTypeSpec.Models
 
         void IJsonModel<Friend>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
+            var format = options.Format == "W" ? ((IPersistableModel<Friend>)this).GetFormatFromOptions(options) : options.Format;
+            if (format != "J")
+            {
+                throw new FormatException($"The model {nameof(Friend)} does not support writing '{format}' format.");
+            }
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name);
+            if (options.Format != "W" && _serializedAdditionalRawData != null)
+            {
+                foreach (var item in _serializedAdditionalRawData)
+                {
+                    writer.WritePropertyName(item.Key);
+#if NET6_0_OR_GREATER
+                    writer.WriteRawValue(item.Value);
+#else
+                    using (JsonDocument document = JsonDocument.Parse(item.Value))
+                    {
+                        JsonSerializer.Serialize(writer, document.RootElement);
+                    }
+#endif
+                }
+            }
         }
 
         Friend IJsonModel<Friend>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/ModelWithRequiredNullableProperties.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/ModelWithRequiredNullableProperties.Serialization.cs
@@ -28,6 +28,62 @@ namespace UnbrandedTypeSpec.Models
 
         void IJsonModel<ModelWithRequiredNullableProperties>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
+            var format = options.Format == "W" ? ((IPersistableModel<ModelWithRequiredNullableProperties>)this).GetFormatFromOptions(options) : options.Format;
+            if (format != "J")
+            {
+                throw new FormatException($"The model {nameof(ModelWithRequiredNullableProperties)} does not support writing '{format}' format.");
+            }
+            if (RequiredNullablePrimitive != null)
+            {
+                writer.WritePropertyName("requiredNullablePrimitive"u8);
+                writer.WriteNumberValue(RequiredNullablePrimitive.Value);
+            }
+            else
+            {
+                writer.WriteNull("requiredNullablePrimitive");
+            }
+            if (RequiredExtensibleEnum != null)
+            {
+                writer.WritePropertyName("requiredExtensibleEnum"u8);
+                writer.WriteStringValue(RequiredExtensibleEnum.Value.ToString());
+            }
+            else
+            {
+                writer.WriteNull("requiredExtensibleEnum");
+            }
+            if (RequiredFixedEnum != null)
+            {
+                writer.WritePropertyName("requiredFixedEnum"u8);
+                writer.WriteStringValue(RequiredFixedEnum.Value.ToSerialString());
+            }
+            else
+            {
+                writer.WriteNull("requiredFixedEnum");
+            }
+            if (options.Format != "W" && _serializedAdditionalRawData != null)
+            {
+                foreach (var item in _serializedAdditionalRawData)
+                {
+                    writer.WritePropertyName(item.Key);
+#if NET6_0_OR_GREATER
+                    writer.WriteRawValue(item.Value);
+#else
+                    using (JsonDocument document = JsonDocument.Parse(item.Value))
+                    {
+                        JsonSerializer.Serialize(writer, document.RootElement);
+                    }
+#endif
+                }
+            }
         }
 
         ModelWithRequiredNullableProperties IJsonModel<ModelWithRequiredNullableProperties>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/ProjectedModel.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/ProjectedModel.Serialization.cs
@@ -26,6 +26,37 @@ namespace UnbrandedTypeSpec.Models
 
         void IJsonModel<ProjectedModel>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
+            var format = options.Format == "W" ? ((IPersistableModel<ProjectedModel>)this).GetFormatFromOptions(options) : options.Format;
+            if (format != "J")
+            {
+                throw new FormatException($"The model {nameof(ProjectedModel)} does not support writing '{format}' format.");
+            }
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name);
+            if (options.Format != "W" && _serializedAdditionalRawData != null)
+            {
+                foreach (var item in _serializedAdditionalRawData)
+                {
+                    writer.WritePropertyName(item.Key);
+#if NET6_0_OR_GREATER
+                    writer.WriteRawValue(item.Value);
+#else
+                    using (JsonDocument document = JsonDocument.Parse(item.Value))
+                    {
+                        JsonSerializer.Serialize(writer, document.RootElement);
+                    }
+#endif
+                }
+            }
         }
 
         ProjectedModel IJsonModel<ProjectedModel>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/ReturnsAnonymousModelResponse.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/ReturnsAnonymousModelResponse.Serialization.cs
@@ -21,6 +21,35 @@ namespace UnbrandedTypeSpec.Models
 
         void IJsonModel<ReturnsAnonymousModelResponse>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
+            var format = options.Format == "W" ? ((IPersistableModel<ReturnsAnonymousModelResponse>)this).GetFormatFromOptions(options) : options.Format;
+            if (format != "J")
+            {
+                throw new FormatException($"The model {nameof(ReturnsAnonymousModelResponse)} does not support writing '{format}' format.");
+            }
+            if (options.Format != "W" && _serializedAdditionalRawData != null)
+            {
+                foreach (var item in _serializedAdditionalRawData)
+                {
+                    writer.WritePropertyName(item.Key);
+#if NET6_0_OR_GREATER
+                    writer.WriteRawValue(item.Value);
+#else
+                    using (JsonDocument document = JsonDocument.Parse(item.Value))
+                    {
+                        JsonSerializer.Serialize(writer, document.RootElement);
+                    }
+#endif
+                }
+            }
         }
 
         ReturnsAnonymousModelResponse IJsonModel<ReturnsAnonymousModelResponse>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/RoundTripModel.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/RoundTripModel.Serialization.cs
@@ -6,6 +6,7 @@ using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
+using UnbrandedTypeSpec;
 
 namespace UnbrandedTypeSpec.Models
 {
@@ -49,6 +50,224 @@ namespace UnbrandedTypeSpec.Models
 
         void IJsonModel<RoundTripModel>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
+            var format = options.Format == "W" ? ((IPersistableModel<RoundTripModel>)this).GetFormatFromOptions(options) : options.Format;
+            if (format != "J")
+            {
+                throw new FormatException($"The model {nameof(RoundTripModel)} does not support writing '{format}' format.");
+            }
+            writer.WritePropertyName("requiredString"u8);
+            writer.WriteStringValue(RequiredString);
+            writer.WritePropertyName("requiredInt"u8);
+            writer.WriteNumberValue(RequiredInt);
+            writer.WritePropertyName("requiredCollection"u8);
+            writer.WriteStartArray();
+            foreach (var item in RequiredCollection)
+            {
+                writer.WriteStringValue(item.ToSerialString());
+            }
+            writer.WriteEndArray();
+            writer.WritePropertyName("requiredDictionary"u8);
+            writer.WriteStartObject();
+            foreach (var item in RequiredDictionary)
+            {
+                writer.WritePropertyName(item.Key);
+                writer.WriteStringValue(item.Value.ToString());
+            }
+            writer.WriteEndObject();
+            writer.WritePropertyName("requiredModel"u8);
+            writer.WriteObjectValue(RequiredModel, options);
+            writer.WritePropertyName("intExtensibleEnum"u8);
+            writer.WriteNumberValue(IntExtensibleEnum.ToSerialInt32());
+            if (Optional.IsCollectionDefined(IntExtensibleEnumCollection))
+            {
+                writer.WritePropertyName("intExtensibleEnumCollection"u8);
+                writer.WriteStartArray();
+                foreach (var item in IntExtensibleEnumCollection)
+                {
+                    writer.WriteNumberValue(item.ToSerialInt32());
+                }
+                writer.WriteEndArray();
+            }
+            writer.WritePropertyName("floatExtensibleEnum"u8);
+            writer.WriteNumberValue(FloatExtensibleEnum.ToSerialSingle());
+            writer.WritePropertyName("floatExtensibleEnumWithIntValue"u8);
+            writer.WriteNumberValue(FloatExtensibleEnumWithIntValue.ToSerialSingle());
+            if (Optional.IsCollectionDefined(FloatExtensibleEnumCollection))
+            {
+                writer.WritePropertyName("floatExtensibleEnumCollection"u8);
+                writer.WriteStartArray();
+                foreach (var item in FloatExtensibleEnumCollection)
+                {
+                    writer.WriteNumberValue(item.ToSerialSingle());
+                }
+                writer.WriteEndArray();
+            }
+            writer.WritePropertyName("floatFixedEnum"u8);
+            writer.WriteNumberValue(FloatFixedEnum.ToSerialSingle());
+            writer.WritePropertyName("floatFixedEnumWithIntValue"u8);
+            writer.WriteNumberValue((int)FloatFixedEnumWithIntValue);
+            if (Optional.IsCollectionDefined(FloatFixedEnumCollection))
+            {
+                writer.WritePropertyName("floatFixedEnumCollection"u8);
+                writer.WriteStartArray();
+                foreach (var item in FloatFixedEnumCollection)
+                {
+                    writer.WriteNumberValue(item.ToSerialSingle());
+                }
+                writer.WriteEndArray();
+            }
+            writer.WritePropertyName("intFixedEnum"u8);
+            writer.WriteNumberValue((int)IntFixedEnum);
+            if (Optional.IsCollectionDefined(IntFixedEnumCollection))
+            {
+                writer.WritePropertyName("intFixedEnumCollection"u8);
+                writer.WriteStartArray();
+                foreach (var item in IntFixedEnumCollection)
+                {
+                    writer.WriteNumberValue((int)item);
+                }
+                writer.WriteEndArray();
+            }
+            writer.WritePropertyName("stringFixedEnum"u8);
+            writer.WriteStringValue(StringFixedEnum.ToSerialString());
+            writer.WritePropertyName("requiredUnknown"u8);
+#if NET6_0_OR_GREATER
+            writer.WriteRawValue(RequiredUnknown);
+#else
+            using (JsonDocument document = JsonDocument.Parse(RequiredUnknown))
+            {
+                JsonSerializer.Serialize(writer, document.RootElement);
+            }
+#endif
+            if (Optional.IsDefined(OptionalUnknown))
+            {
+                writer.WritePropertyName("optionalUnknown"u8);
+#if NET6_0_OR_GREATER
+                writer.WriteRawValue(OptionalUnknown);
+#else
+                using (JsonDocument document = JsonDocument.Parse(OptionalUnknown))
+                {
+                    JsonSerializer.Serialize(writer, document.RootElement);
+                }
+#endif
+            }
+            writer.WritePropertyName("requiredRecordUnknown"u8);
+            writer.WriteStartObject();
+            foreach (var item in RequiredRecordUnknown)
+            {
+                writer.WritePropertyName(item.Key);
+                if (item.Value == null)
+                {
+                    writer.WriteNullValue();
+                    continue;
+                }
+#if NET6_0_OR_GREATER
+                writer.WriteRawValue(item.Value);
+#else
+                using (JsonDocument document = JsonDocument.Parse(item.Value))
+                {
+                    JsonSerializer.Serialize(writer, document.RootElement);
+                }
+#endif
+            }
+            writer.WriteEndObject();
+            if (Optional.IsCollectionDefined(OptionalRecordUnknown))
+            {
+                writer.WritePropertyName("optionalRecordUnknown"u8);
+                writer.WriteStartObject();
+                foreach (var item in OptionalRecordUnknown)
+                {
+                    writer.WritePropertyName(item.Key);
+                    if (item.Value == null)
+                    {
+                        writer.WriteNullValue();
+                        continue;
+                    }
+#if NET6_0_OR_GREATER
+                    writer.WriteRawValue(item.Value);
+#else
+                    using (JsonDocument document = JsonDocument.Parse(item.Value))
+                    {
+                        JsonSerializer.Serialize(writer, document.RootElement);
+                    }
+#endif
+                }
+                writer.WriteEndObject();
+            }
+            if (options.Format != "W")
+            {
+                writer.WritePropertyName("readOnlyRequiredRecordUnknown"u8);
+                writer.WriteStartObject();
+                foreach (var item in ReadOnlyRequiredRecordUnknown)
+                {
+                    writer.WritePropertyName(item.Key);
+                    if (item.Value == null)
+                    {
+                        writer.WriteNullValue();
+                        continue;
+                    }
+#if NET6_0_OR_GREATER
+                    writer.WriteRawValue(item.Value);
+#else
+                    using (JsonDocument document = JsonDocument.Parse(item.Value))
+                    {
+                        JsonSerializer.Serialize(writer, document.RootElement);
+                    }
+#endif
+                }
+                writer.WriteEndObject();
+            }
+            if (options.Format != "W" && Optional.IsCollectionDefined(ReadOnlyOptionalRecordUnknown))
+            {
+                writer.WritePropertyName("readOnlyOptionalRecordUnknown"u8);
+                writer.WriteStartObject();
+                foreach (var item in ReadOnlyOptionalRecordUnknown)
+                {
+                    writer.WritePropertyName(item.Key);
+                    if (item.Value == null)
+                    {
+                        writer.WriteNullValue();
+                        continue;
+                    }
+#if NET6_0_OR_GREATER
+                    writer.WriteRawValue(item.Value);
+#else
+                    using (JsonDocument document = JsonDocument.Parse(item.Value))
+                    {
+                        JsonSerializer.Serialize(writer, document.RootElement);
+                    }
+#endif
+                }
+                writer.WriteEndObject();
+            }
+            writer.WritePropertyName("modelWithRequiredNullable"u8);
+            writer.WriteObjectValue(ModelWithRequiredNullable, options);
+            writer.WritePropertyName("requiredBytes"u8);
+            writer.WriteBase64StringValue(RequiredBytes.ToArray(), "D");
+            if (options.Format != "W" && _serializedAdditionalRawData != null)
+            {
+                foreach (var item in _serializedAdditionalRawData)
+                {
+                    writer.WritePropertyName(item.Key);
+#if NET6_0_OR_GREATER
+                    writer.WriteRawValue(item.Value);
+#else
+                    using (JsonDocument document = JsonDocument.Parse(item.Value))
+                    {
+                        JsonSerializer.Serialize(writer, document.RootElement);
+                    }
+#endif
+                }
+            }
         }
 
         RoundTripModel IJsonModel<RoundTripModel>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)

--- a/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/Thing.Serialization.cs
+++ b/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/Thing.Serialization.cs
@@ -6,6 +6,7 @@ using System;
 using System.ClientModel.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
+using UnbrandedTypeSpec;
 
 namespace UnbrandedTypeSpec.Models
 {
@@ -38,6 +39,95 @@ namespace UnbrandedTypeSpec.Models
 
         void IJsonModel<Thing>.Write(Utf8JsonWriter writer, ModelReaderWriterOptions options)
         {
+            writer.WriteStartObject();
+            JsonModelWriteCore(writer, options);
+            writer.WriteEndObject();
+        }
+
+        /// <param name="writer"> The JSON writer. </param>
+        /// <param name="options"> The client options for reading and writing models. </param>
+        protected virtual void JsonModelWriteCore(Utf8JsonWriter writer, ModelReaderWriterOptions options)
+        {
+            var format = options.Format == "W" ? ((IPersistableModel<Thing>)this).GetFormatFromOptions(options) : options.Format;
+            if (format != "J")
+            {
+                throw new FormatException($"The model {nameof(Thing)} does not support writing '{format}' format.");
+            }
+            writer.WritePropertyName("name"u8);
+            writer.WriteStringValue(Name);
+            writer.WritePropertyName("requiredUnion"u8);
+#if NET6_0_OR_GREATER
+            writer.WriteRawValue(RequiredUnion);
+#else
+            using (JsonDocument document = JsonDocument.Parse(RequiredUnion))
+            {
+                JsonSerializer.Serialize(writer, document.RootElement);
+            }
+#endif
+            writer.WritePropertyName("requiredLiteralString"u8);
+            writer.WriteStringValue(RequiredLiteralString.ToString());
+            writer.WritePropertyName("requiredLiteralInt"u8);
+            writer.WriteNumberValue(RequiredLiteralInt.ToSerialInt32());
+            writer.WritePropertyName("requiredLiteralFloat"u8);
+            writer.WriteNumberValue(RequiredLiteralFloat.ToSerialSingle());
+            writer.WritePropertyName("requiredLiteralBool"u8);
+            writer.WriteBooleanValue(RequiredLiteralBool);
+            writer.WritePropertyName("optionalLiteralString"u8);
+            writer.WriteStringValue(OptionalLiteralString.ToString());
+            writer.WritePropertyName("optionalLiteralInt"u8);
+            writer.WriteNumberValue(OptionalLiteralInt.ToSerialInt32());
+            writer.WritePropertyName("optionalLiteralFloat"u8);
+            writer.WriteNumberValue(OptionalLiteralFloat.ToSerialSingle());
+            writer.WritePropertyName("optionalLiteralBool"u8);
+            writer.WriteBooleanValue(OptionalLiteralBool);
+            writer.WritePropertyName("requiredBadDescription"u8);
+            writer.WriteStringValue(RequiredBadDescription);
+            if (Optional.IsCollectionDefined(OptionalNullableList))
+            {
+                if (OptionalNullableList != null)
+                {
+                    writer.WritePropertyName("optionalNullableList"u8);
+                    writer.WriteStartArray();
+                    foreach (var item in OptionalNullableList)
+                    {
+                        writer.WriteNumberValue(item);
+                    }
+                    writer.WriteEndArray();
+                }
+                else
+                {
+                    writer.WriteNull("optionalNullableList");
+                }
+            }
+            if (RequiredNullableList != null && Optional.IsCollectionDefined(RequiredNullableList))
+            {
+                writer.WritePropertyName("requiredNullableList"u8);
+                writer.WriteStartArray();
+                foreach (var item in RequiredNullableList)
+                {
+                    writer.WriteNumberValue(item);
+                }
+                writer.WriteEndArray();
+            }
+            else
+            {
+                writer.WriteNull("requiredNullableList");
+            }
+            if (options.Format != "W" && _serializedAdditionalRawData != null)
+            {
+                foreach (var item in _serializedAdditionalRawData)
+                {
+                    writer.WritePropertyName(item.Key);
+#if NET6_0_OR_GREATER
+                    writer.WriteRawValue(item.Value);
+#else
+                    using (JsonDocument document = JsonDocument.Parse(item.Value))
+                    {
+                        JsonSerializer.Serialize(writer, document.RootElement);
+                    }
+#endif
+                }
+            }
         }
 
         Thing IJsonModel<Thing>.Create(ref Utf8JsonReader reader, ModelReaderWriterOptions options)


### PR DESCRIPTION
This PR decouples the changes from https://github.com/microsoft/typespec/pull/3603 to support generating the Json Model Write method for a model.

It also depends on https://github.com/microsoft/typespec/pull/3634.

Supports https://github.com/microsoft/typespec/issues/3330.